### PR TITLE
#6: Remove Trigger Condition From Create-Release Reusable Workflow.

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -12,7 +12,6 @@ on:
 
 jobs:
   create-release:
-    if: github.ref_type == 'tag'
     permissions:
       contents: write
     runs-on: ${{ inputs.ubuntu-version }}


### PR DESCRIPTION
Resolves #6 for reopening comment [here](https://github.com/atomic-works/github-actions-reusable-workflows/issues/6#issuecomment-1789920876).